### PR TITLE
Remove unnecessary message check

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -102,10 +102,6 @@ async def on_message(message: discord.Message):
     # ignore messages sent by bots
     if message.author.bot:
         return
-
-    # ignore self
-    if message.author == client.user:
-        return
     
     # ignore message if not mentioned
     if not discordHelpers.utils.isMentioned(message.mentions, client.user):


### PR DESCRIPTION
Message is already ignored if the author is a bot, why another unnecessary check for itself?